### PR TITLE
V1.2.1 - Compatibility with Augmented Equipment

### DIFF
--- a/NoDurabilityPlus/NoDurabilityPlus.cs
+++ b/NoDurabilityPlus/NoDurabilityPlus.cs
@@ -135,10 +135,7 @@ public class NoDurabilityPlus : Mod
         catch (Exception e)
         {
             Log("Exception: " + e.Message);
-            if (!Harmony.HasAnyPatches("com.bahamut.augmentedequipment"))
-            {
-                Debug.LogException(e);
-            }
+            Debug.LogException(e);
         }
         return ret;
     }

--- a/NoDurabilityPlus/NoDurabilityPlus.csproj
+++ b/NoDurabilityPlus/NoDurabilityPlus.csproj
@@ -311,19 +311,19 @@
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data/Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="0Harmony.dll">
-      <HintPath>C:\Users\barpi\AppData\Roaming\RaftModLoader\binaries\0Harmony.dll</HintPath>
+      <HintPath>C:\Users\nicho\AppData\Roaming\RaftModLoader\binaries\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="coremod.dll">
-      <HintPath>C:\Users\barpi\AppData\Roaming\RaftModLoader\binaries\coremod.dll</HintPath>
+      <HintPath>C:\Users\nicho\AppData\Roaming\RaftModLoader\binaries\coremod.dll</HintPath>
     </Reference>
     <Reference Include="HMLCoreLibrary.dll">
-      <HintPath>C:\Users\barpi\AppData\Roaming\RaftModLoader\binaries\HMLCoreLibrary.dll</HintPath>
+      <HintPath>C:\Users\nicho\AppData\Roaming\RaftModLoader\binaries\HMLCoreLibrary.dll</HintPath>
     </Reference>
     <Reference Include="SharpZipLib.dll">
-      <HintPath>C:\Users\barpi\AppData\Roaming\RaftModLoader\binaries\SharpZipLib.dll</HintPath>
+      <HintPath>C:\Users\nicho\AppData\Roaming\RaftModLoader\binaries\SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple.dll">
-      <HintPath>C:\Users\barpi\AppData\Roaming\RaftModLoader\binaries\System.ValueTuple.dll</HintPath>
+      <HintPath>C:\Users\nicho\AppData\Roaming\RaftModLoader\binaries\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup>

--- a/NoDurabilityPlus/modinfo.json
+++ b/NoDurabilityPlus/modinfo.json
@@ -2,7 +2,7 @@
   "name": "No Durability Plus",
   "author": "ArmyOfOptimists",
   "description": "Allows modification of durability by slot and item type.  Requires ExtraSettingsAPI to configure, otherwise all items will have infinite durability.  Based on the original 'Almost No Durability' mod by Aidanamite.",
-  "version": "v1.2.0",
+  "version": "v1.2.1",
   "license": "GNU AGPLv3",
   "icon": "icon.png",
   "banner": "banner.jpg",
@@ -93,6 +93,63 @@
       "text": "Oxygen Bottle Durability Modifier",
       "type": "combobox",
       "access": "both",
+      "default": "infinite",
+      "values": [
+        "infinite",
+        "1x (original)",
+        "2x",
+        "3x",
+        "4x",
+        "5x",
+        "6x",
+        "7x",
+        "8x",
+        "9x"
+      ]
+    },
+    {
+      "name": "Light",
+      "text": "Light Durability Modifier",
+      "type": "combobox",
+      "access": "globalcustom",
+      "default": "infinite",
+      "values": [
+        "infinite",
+        "1x (original)",
+        "2x",
+        "3x",
+        "4x",
+        "5x",
+        "6x",
+        "7x",
+        "8x",
+        "9x"
+      ]
+    },
+    {
+      "name": "SwimFeet",
+      "text": "SwimFeet Durability Modifier",
+      "type": "combobox",
+      "access": "globalcustom",
+      "default": "infinite",
+      "values": [
+        "infinite",
+        "1x (original)",
+        "2x",
+        "3x",
+        "4x",
+        "5x",
+        "6x",
+        "7x",
+        "8x",
+        "9x"
+      ]
+    },
+    {
+      "name": "Glove",
+      "text": "Glove Durability Modifier",
+      "type": "combobox",
+      "access": "globalcustom",
       "default": "infinite",
       "values": [
         "infinite",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+v1.2.1
+- Added compatibility with the Augmented Equipment mod
+
 v1.1.2
 - updated version string to match site and fix versioning issue
 


### PR DESCRIPTION
Added the capability for NoDurabilityPlus to understand the CustomEquipmentItems by adding the CustomEquipmentItem classes methods to the code and also adding 2nd dictionary to convert the arbitrary string numbers 1-10 into their respective EquipSlots (e.g. [Belt] and [SwimFeet]). Furthermore, also added some new options that allow the editing of the new EquipSlots and they only appear if the mod is detected to be installed and running via a harmony method.